### PR TITLE
fix: Restructure fetch logic to avoid extraneous network calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ npm install
 
 The project uses [the Serverless Framework](https://serverless.com/) and currently includes one function to run every six hours.
 
-### `tweet` – scheduled function (every 6 hours)
+### `tweet` – scheduled function (every 4 hours)
 
 The tweet function reads out the MDN sitemap, parses it and tweets the found article.
 

--- a/handler.js
+++ b/handler.js
@@ -52,14 +52,14 @@ const tweet = promisify(twitter.post.bind(twitter));
 const onlyAllowWebUrls = (url) => url.startsWith(WEB_PATH);
 
 /**
- * Get URL to tweet
+ * Get all MDN Web Documentation URLs
  *   - fetch MDN sitemap
- *   - parse it
- *   - grab a random URL
+ *   - unzip response
+ *   - filter out non-web-documentation URLs
  *
  * @returns {Promise} A random URL from the MDN sitemap
  */
-const getUrlToTweet = async () => {
+const getWebDocUrls = async () => {
   const SITEMAP_URL_REGEX = /<loc>(.*?)<\/loc>/g;
   const { body } = await got(SITEMAP_URL, {
     responseType: 'buffer',
@@ -73,9 +73,8 @@ const getUrlToTweet = async () => {
   }
 
   const webDocUrls = allDocUrls.filter(onlyAllowWebUrls);
-  const urlToTweet = webDocUrls[Math.floor(webDocUrls.length * Math.random())];
 
-  return urlToTweet;
+  return webDocUrls;
 };
 
 /**
@@ -175,9 +174,12 @@ module.exports.tweet = async () => {
     let description;
     let title;
 
+    const webDocUrls = await getWebDocUrls();
+
     // loop over it because many pages don't include a description
     while (!title || !description) {
-      urlToTweet = await getUrlToTweet();
+      // grab a random URL
+      urlToTweet = webDocUrls[Math.floor(webDocUrls.length * Math.random())];
       [title, description] = await getTitleAndDescription(urlToTweet);
     }
 


### PR DESCRIPTION
This PR moves the Web Documentation URL fetching logic out of the main while loop to avoid extraneous network calls for the MDN sitemap. I'm guessing it's rare the `title` and `description` aren't present, which triggers the re-fetch, but it doesn't hurt to optimize the edge case (: