### PR TITLE
feat: replace title HTML `<code>` with backticks

### DIFF
--- a/lib/mdn-article.js
+++ b/lib/mdn-article.js
@@ -70,10 +70,17 @@ export const getArticleMetadata = async (url) => {
   if (DEPRECATION_REGEX.test(doc)) return;
 
   const metadata = {
-    // Strip html comments (<!--lit-part-->...<!--/lit-part-->)
-    title: doc.match(TITLE_REGEX)?.[1]?.replace(/<!--[\s\S]*?-->/g, ''),
-    // Normalize text by removing all extra whitespace (including spaces, tabs, and line breaks)
-    description: doc.match(DESCRIPTION_REGEX)?.[1].replace(/\s+/g, ' ').trim(),
+    title: doc
+      .match(TITLE_REGEX)?.[1]
+      // Strip html comments (<!--lit-part-->...<!--/lit-part-->)
+      .replace(/<!--[\s\S]*?-->/g, '')
+      // Replace HTML <code> tags with backticks
+      .replace(/<code>(.*?)<\/code>/g, '`$1`'),
+    description: doc
+      .match(DESCRIPTION_REGEX)?.[1]
+      // Normalize text by removing all extra whitespace (including spaces, tabs, and line breaks)
+      .replace(/\s+/g, ' ')
+      .trim(),
     hashtags: getHashtags(url),
     image: doc.match(IMAGE_REGEX)?.[1],
   };

--- a/lib/mdn-article.test.js
+++ b/lib/mdn-article.test.js
@@ -5,7 +5,7 @@ test('getArticleMetadata', async () => {
   await expect(
     getArticleMetadata('https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head'),
   ).resolves.toStrictEqual({
-    title: '<code><head></code> HTML document …',
+    title: '`<head>` HTML document metadata (h…',
     description:
       'The <head> HTML element contains machine-readable information (metadata) about the document, like its title, scripts, and style sheets. There can be only one <head> element in an HTML document.',
     hashtags: ['#webdev', '#HTML'],


### PR DESCRIPTION
## What changed (additional context)

Replace title HTML `<code>` with backticks.

Related: 
- https://github.com/mdn/content/pull/43893
- https://github.com/mdn/content/pull/43831
- ...

## Proof of work (screenshots / screen recordings)

<!-- Please provide before/after screenshots for any visual changes -->

| before | after |
| ------ | ----- |
| <img width="1200" height="1590" alt="before" src="https://github.com/user-attachments/assets/c6c1518c-a401-4a23-bb58-380001db9c6d" /> | <img width="1200" height="1590" alt="after" src="https://github.com/user-attachments/assets/f0bc1d08-217f-4cf6-b06e-c1a6ba2c4187" /> |
